### PR TITLE
Update so daemonip works with signalr

### DIFF
--- a/StratisCore.UI/src/app/shared/services/signalr-service.ts
+++ b/StratisCore.UI/src/app/shared/services/signalr-service.ts
@@ -12,7 +12,7 @@ import { Log } from '../../wallet/tokens/services/logger.service';
 
 export interface SignalRConnectionInfo {
   signalRUri: string;
-  signalPort: string;
+  signalRPort: string;
 }
 
 export interface SignalRMessageHandler {
@@ -59,7 +59,7 @@ export class SignalRService extends RestApi implements ISignalRService {
       }
 
       this.connection = new signalR.HubConnectionBuilder()
-        .withUrl(`http://${this.globalService.getDaemonIP()}:${con.signalPort}/${hubName}-hub`, {})
+        .withUrl(`http://${this.globalService.getDaemonIP()}:${con.signalRPort}/${hubName}-hub`, {})
         .configureLogging(signalR.LogLevel.Information)
         .build();
 

--- a/StratisCore.UI/src/app/shared/services/signalr-service.ts
+++ b/StratisCore.UI/src/app/shared/services/signalr-service.ts
@@ -12,7 +12,7 @@ import { Log } from '../../wallet/tokens/services/logger.service';
 
 export interface SignalRConnectionInfo {
   signalRUri: string;
-  signalRPort: string;
+  signalPort: string;
 }
 
 export interface SignalRMessageHandler {
@@ -59,7 +59,7 @@ export class SignalRService extends RestApi implements ISignalRService {
       }
 
       this.connection = new signalR.HubConnectionBuilder()
-        .withUrl(`${con.signalRUri}/${hubName}-hub`, {})
+        .withUrl(`http://${this.globalService.getDaemonIP()}:${con.signalPort}/${hubName}-hub`, {})
         .configureLogging(signalR.LogLevel.Information)
         .build();
 


### PR DESCRIPTION
2 minor changes so that daemonip works with the new Strax wallet. This makes it easier for running a headless node for staking on devices such as RPi, connecting the UI only when needed. 

1. The api/signalR/getConnectionInfo Strax endpoint returns 'signalRUri' and 'signalPort' json keys. Fixed the SignalRConnectionInfo interface for 'signalPort'.

2. Updated the hub connection builder to use daemonip from globalservice. I did not to define the signalR port in globalservice in case the user defines 'signalrport' in their strax.conf file, which will be returned by the change above. 