### PR TITLE
Enable getdaemonip in StraxUI

### DIFF
--- a/src/app/shared/services/signalr-service.ts
+++ b/src/app/shared/services/signalr-service.ts
@@ -12,7 +12,7 @@ import { LoggerService } from '@shared/services/logger.service';
 
 export interface SignalRConnectionInfo {
   signalRUri: string;
-  //signalRPort: string;
+  signalRPort: string;
 }
 
 export interface SignalRMessageHandler {
@@ -60,8 +60,7 @@ export class SignalRService extends RestApi implements ISignalRService {
       }
 
       this.connection = new signalR.HubConnectionBuilder()
-        //.withUrl(`http://${this.globalService.getDaemonIP()}:${con.signalRPort}/${hubName}-hub`, {})
-        .withUrl(`${con.signalRUri}/${hubName}-hub`, {})
+        .withUrl(`http://${this.globalService.getDaemonIP()}:${con.signalRPort}/${hubName}-hub`, {})
         .configureLogging(signalR.LogLevel.Information)
         .build();
 


### PR DESCRIPTION
Enable functionality fixed with [#513](https://github.com/stratisproject/StratisFullNode/commit/c5cecdfd9ed5901f1b6d392e5acf568d035a5ccd). 

- Specifically, this change enables the daemonip flag for connecting the straxui to a node at another ip. 